### PR TITLE
Rewritten examples in section "init-statements for if and switch"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -679,13 +679,11 @@ New versions of the if and switch statements for C++: `if (init; condition)` and
 This should simplify the code. For example, previously you had to write:
 
 ```cpp
-{   
-    auto val = GetValue();   
-    if (val)    
-        // on success  
-    else   
-        // on false... 
-}
+int val = GetValue();
+if (val != 42)
+    // on success
+else
+    // on false...
 ```
 
 Look, that `val` has a separate scope, without it it will 'leak'.
@@ -693,10 +691,10 @@ Look, that `val` has a separate scope, without it it will 'leak'.
 Now you can write:
 
 ```cpp 
-if (auto val = GetValue(); val)    
-    // on success  
-else   
-    // on false... 
+if (int val = GetValue(); val != 42)
+    // on success
+else
+    // on false...
 ```
 
 `val` is visible only inside the `if` and `else` statements, so it doesn't 'leak'.


### PR DESCRIPTION
Rewritten examples in section "init-statements for if and switch" section to better show the innovation introduced in C++17. The original examples where misleading, since in C++11 you could write code that is more concise than both of them.